### PR TITLE
Fix minor/major changes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,6 +24,7 @@ AC_CONFIG_MACRO_DIR([m4])
 
 AC_USE_SYSTEM_EXTENSIONS
 AC_SYS_LARGEFILE
+AC_HEADER_MAJOR
 
 AM_INIT_AUTOMAKE([1.11 parallel-tests foreign no-dist-gzip dist-xz color-tests subdir-objects])
 

--- a/src/launcher-direct.c
+++ b/src/launcher-direct.c
@@ -43,6 +43,14 @@
 #define KDSKBMUTE	0x4B51
 #endif
 
+/* major()/minor() */
+#ifdef MAJOR_IN_MKDEV
+#	include <sys/mkdev.h>
+#endif
+#ifdef MAJOR_IN_SYSMACROS
+#	include <sys/sysmacros.h>
+#endif
+
 #ifdef HAVE_LIBDRM
 
 #include <xf86drm.h>

--- a/src/launcher-logind.c
+++ b/src/launcher-logind.c
@@ -43,6 +43,14 @@
 
 #define DRM_MAJOR 226
 
+/* major()/minor() */
+#ifdef MAJOR_IN_MKDEV
+#	include <sys/mkdev.h>
+#endif
+#ifdef MAJOR_IN_SYSMACROS
+#	include <sys/sysmacros.h>
+#endif
+
 struct launcher_logind {
 	struct weston_launcher base;
 	struct weston_compositor *compositor;

--- a/src/launcher-weston-launch.c
+++ b/src/launcher-weston-launch.c
@@ -50,6 +50,14 @@
 #define KDSKBMUTE	0x4B51
 #endif
 
+/* major()/minor() */
+#ifdef MAJOR_IN_MKDEV
+#	include <sys/mkdev.h>
+#endif
+#ifdef MAJOR_IN_SYSMACROS
+#	include <sys/sysmacros.h>
+#endif
+
 #ifdef HAVE_LIBDRM
 
 #include <xf86drm.h>

--- a/src/weston-launch.c
+++ b/src/weston-launch.c
@@ -60,6 +60,14 @@
 
 #include "weston-launch.h"
 
+/* major()/minor() */
+#ifdef MAJOR_IN_MKDEV
+#    include <sys/mkdev.h>
+#endif
+#ifdef MAJOR_IN_SYSMACROS
+#    include <sys/sysmacros.h>
+#endif
+
 #define DRM_MAJOR 226
 
 #ifndef KDSKBMUTE


### PR DESCRIPTION
glibc removed <sys/sysmacros.h> from glibc's <sys/types.h>:
    https://sourceware.org/ml/libc-alpha/2015-11/msg00253.html

Compile failed without this fix on Ubuntu 19.10 / 20.04 (but still worked on 18.04)